### PR TITLE
Add GitLab support as codeHost option

### DIFF
--- a/src/azure/index.mjs
+++ b/src/azure/index.mjs
@@ -15,7 +15,11 @@ async function run() {
 
     const project = process.env.SYSTEM_TEAMPROJECT ?? "";
 
-    const body = buildCommentBody({ owner, project, workItemId });
+    const codeHost = taskLib.getInput("codeHost") || "github";
+    const gitlabOwner = taskLib.getInput("gitlabOwner") || undefined;
+    const gitlabRepo = taskLib.getInput("gitlabRepo") || undefined;
+
+    const body = buildCommentBody({ owner, project, workItemId, codeHost, gitlabOwner, gitlabRepo });
 
     const url = `https://dev.azure.com/${owner}/${encodeURIComponent(project)}/_apis/wit/workItems/${workItemId}/comments?api-version=7.1`;
 

--- a/src/comment.mjs
+++ b/src/comment.mjs
@@ -1,7 +1,13 @@
 const BASE_URL = "https://worktree.io"; // eslint-disable-line default/no-hardcoded-urls
 
-export function buildCommentBody({ owner, project, workItemId }) {
-  const url = `${BASE_URL}/open?owner=${owner}&project=${encodeURIComponent(project)}&workItem=${workItemId}`;
+export function buildCommentBody({ owner, project, workItemId, codeHost = "github", gitlabOwner, gitlabRepo }) {
+  const params = new URLSearchParams({ owner, project, workItem: workItemId });
+  if (codeHost === "gitlab") {
+    params.set("codeHost", "gitlab");
+    params.set("gitlabOwner", gitlabOwner ?? "");
+    params.set("gitlabRepo", gitlabRepo ?? "");
+  }
+  const url = `${BASE_URL}/open?${params.toString()}`;
 
   return [
     "A workspace is ready for this work item.",

--- a/task.json
+++ b/task.json
@@ -25,6 +25,36 @@
       "defaultValue": "$(System.WorkItemId)",
       "required": true,
       "helpMarkDown": "The ID of the work item to comment on. Populated automatically by the service hook trigger."
+    },
+    {
+      "name": "codeHost",
+      "type": "pickList",
+      "label": "Code Host",
+      "defaultValue": "github",
+      "required": false,
+      "helpMarkDown": "The code hosting service for the paired repository.",
+      "options": {
+        "github": "GitHub",
+        "gitlab": "GitLab"
+      }
+    },
+    {
+      "name": "gitlabOwner",
+      "type": "string",
+      "label": "GitLab Owner",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "The GitLab namespace (user or group) of the paired repository. Required when Code Host is GitLab.",
+      "visibleRule": "codeHost = gitlab"
+    },
+    {
+      "name": "gitlabRepo",
+      "type": "string",
+      "label": "GitLab Repository",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "The GitLab repository name. Required when Code Host is GitLab.",
+      "visibleRule": "codeHost = gitlab"
     }
   ],
   "execution": {


### PR DESCRIPTION
## Summary

- Adds a `codeHost` pickList input (`github` / `gitlab`, default: `github`) to `task.json`
- Adds `gitlabOwner` and `gitlabRepo` string inputs that are only visible when `codeHost = gitlab`
- Updates `buildCommentBody` in `src/comment.mjs` to include `codeHost`, `gitlabOwner`, and `gitlabRepo` query params when GitLab is selected
- Reads the new inputs in `src/azure/index.mjs` and passes them through to `buildCommentBody`

Closes #2

## Test plan

- [ ] Default behavior (no `codeHost` input or `codeHost=github`): URL is unchanged — no extra params appended
- [ ] `codeHost=gitlab` with `gitlabOwner=mygroup` and `gitlabRepo=myrepo`: URL contains `codeHost=gitlab&gitlabOwner=mygroup&gitlabRepo=myrepo`
- [ ] `gitlabOwner` and `gitlabRepo` inputs are only visible in the ADO task UI when `codeHost = gitlab`

🤖 Generated with [Claude Code](https://claude.com/claude-code)