### PR TITLE
Add tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm test

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "ncc build src/azure/index.mjs -o dist --license licenses.txt",
     "vsix": "pnpm build && node scripts/assemble.mjs && tfx extension create --manifest-globs vss-extension.json",
     "publish:marketplace": "pnpm build && node scripts/assemble.mjs && tfx extension publish --manifest-globs vss-extension.json --token $MARKETPLACE_TOKEN",
+    "test": "node --test 'src/**/*.test.mjs'",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prepare": "husky"

--- a/src/comment.test.mjs
+++ b/src/comment.test.mjs
@@ -1,0 +1,42 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildCommentBody } from "./comment.mjs";
+
+describe("buildCommentBody", () => {
+  it("returns a string containing the badge link", () => {
+    const body = buildCommentBody({ owner: "myorg", project: "MyProject", workItemId: "42" });
+    assert.ok(body.includes("Open_workspace"), "badge text missing");
+    assert.ok(body.includes("https://worktree.io/open?"), "URL missing");
+  });
+
+  it("includes owner, project, and workItemId in the URL", () => {
+    const body = buildCommentBody({ owner: "acme", project: "Web App", workItemId: "7" });
+    assert.ok(body.includes("owner=acme"), "owner missing from URL");
+    assert.ok(body.includes("project=Web+App"), "project missing from URL");
+    assert.ok(body.includes("workItem=7"), "workItemId missing from URL");
+  });
+
+  it("defaults to github codeHost and omits codeHost param", () => {
+    const body = buildCommentBody({ owner: "org", project: "proj", workItemId: "1" });
+    assert.ok(!body.includes("codeHost="), "codeHost should not appear for default github");
+  });
+
+  it("adds GitLab params when codeHost is gitlab", () => {
+    const body = buildCommentBody({
+      owner: "org",
+      project: "proj",
+      workItemId: "1",
+      codeHost: "gitlab",
+      gitlabOwner: "glorg",
+      gitlabRepo: "glrepo",
+    });
+    assert.ok(body.includes("codeHost=gitlab"), "codeHost=gitlab missing");
+    assert.ok(body.includes("gitlabOwner=glorg"), "gitlabOwner missing");
+    assert.ok(body.includes("gitlabRepo=glrepo"), "gitlabRepo missing");
+  });
+
+  it("includes the footer with Worktree branding", () => {
+    const body = buildCommentBody({ owner: "org", project: "proj", workItemId: "1" });
+    assert.ok(body.includes("Powered by [Worktree]"), "footer branding missing");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/comment.test.mjs` with 5 unit tests for `buildCommentBody` (GitHub default, GitLab params, URL shape, branding footer)
- Add `pnpm test` script using Node.js built-in test runner (no extra deps)
- Add `.github/workflows/ci.yml` that runs tests on PRs and pushes to `main`

## Test plan

- [x] `pnpm test` passes locally (5/5)
- [ ] CI runs green on this PR

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)